### PR TITLE
:sparkles: creates dropdown component for the word list

### DIFF
--- a/src/components/Button/button.module.scss
+++ b/src/components/Button/button.module.scss
@@ -4,7 +4,7 @@
 .btn {
   color: $black;
   background-color: $white;
-  border: 1.5px solid $black;
+  border: 1px solid $black;
   border-radius: $brad-m;
   height: 2.7rem;
 }

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -25,7 +25,7 @@ export const Dropdown = ({ foundWords }: DropdownProps) => {
   return (
     <div className={styles.dropdown}>
       <button
-        className={classNames(styles.dropdownBtn, open && styles.radiusNull)}
+        className={classNames(styles.dropdownBtn, open && styles.active)}
         onClick={handleClick}
       >
         {!open ? (

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -1,0 +1,51 @@
+'use client';
+
+import { useState } from 'react';
+import { BiSolidDownArrow } from 'react-icons/bi';
+import { BiSolidUpArrow } from 'react-icons/bi';
+import classNames from 'classnames';
+import styles from './dropdown.module.scss';
+
+type DropdownProps = {
+  foundWords: string[];
+};
+
+export const Dropdown = ({ foundWords }: DropdownProps) => {
+  const [open, setOpen] = useState(false);
+
+  const recentGuesses = foundWords.slice(0).reverse().join(' ').slice(0, 41).concat('...');
+
+  const guessesList = foundWords
+    .slice(0)
+    .sort((a, b) => a.slice(0).toLowerCase().localeCompare(b.slice(0).toLowerCase()))
+    .join(' ');
+
+  const handleClick = () => setOpen(!open);
+
+  return (
+    <div className={styles.dropdown}>
+      <button
+        className={classNames(styles.dropdownBtn, open && styles.radiusNull)}
+        onClick={handleClick}
+      >
+        {!open ? (
+          <>
+            <span>{recentGuesses}</span>
+            <BiSolidDownArrow className={styles.arrowBtn} />
+          </>
+        ) : (
+          <>
+            <span>{`Du hast ${foundWords.length} Wörter gefunden`}</span>
+            <BiSolidUpArrow className={styles.arrowBtn} />
+          </>
+        )}
+      </button>
+
+      {open && (
+        <div className={styles.dropdownContent} onClick={handleClick}>
+          {guessesList}
+        </div>
+      )}
+    </div>
+  );
+};

--- a/src/components/Dropdown/dropdown.module.scss
+++ b/src/components/Dropdown/dropdown.module.scss
@@ -1,0 +1,60 @@
+@import '@/styles/mediaQueries.scss';
+@import '@/styles/variables.scss';
+@import '@/styles/colors.scss';
+
+.dropdown {
+  position: relative;
+  /* display: inline-block; */
+
+  .dropdownBtn {
+    display: flex;
+    justify-content: space-between;
+    width: 100%;
+    background-color: $white;
+    border: 1.5px solid $black;
+    border-radius: $brad-sm;
+    padding: 0.5rem;
+    padding-top: 0.75rem;
+
+    .arrowBtn {
+      width: 1.3rem;
+      height: 1.3rem;
+
+      &:hover {
+        cursor: pointer;
+      }
+    }
+  }
+
+  .radiusNull {
+    border-bottom-left-radius: 0;
+    border-bottom-right-radius: 0;
+  }
+
+  .dropdownContent {
+    position: absolute;
+    width: 100%;
+    height: 40rem;
+    overflow: scroll;
+    background-color: $white;
+    color: $black;
+    font-size: 0.85rem;
+    border: 1.5px solid $black;
+    border-top: 0;
+    border-bottom-left-radius: $brad-sm;
+    border-bottom-right-radius: $brad-sm;
+    padding: 0.5rem;
+
+    &:hover {
+      cursor: pointer;
+    }
+  }
+}
+
+@include tablet {
+  .dropdown {
+    .dropdownContent {
+      height: 45rem;
+    }
+  }
+}

--- a/src/components/Dropdown/dropdown.module.scss
+++ b/src/components/Dropdown/dropdown.module.scss
@@ -45,7 +45,7 @@
     cursor: pointer;
 
     @include tablet {
-      height: 44rem;
+      height: 45rem;
     }
   }
 }

--- a/src/components/Dropdown/dropdown.module.scss
+++ b/src/components/Dropdown/dropdown.module.scss
@@ -5,7 +5,6 @@
 .dropdown {
   position: relative;
   z-index: 4;
-  /* display: inline-block; */
 
   .dropdownBtn {
     display: flex;
@@ -44,7 +43,7 @@
     padding: 0.5rem;
     cursor: pointer;
 
-    @include tablet {
+    @include mobile {
       height: 45rem;
     }
   }

--- a/src/components/Dropdown/dropdown.module.scss
+++ b/src/components/Dropdown/dropdown.module.scss
@@ -32,8 +32,7 @@
   .dropdownContent {
     position: absolute;
     width: 100%;
-    min-height: 39rem;
-    max-height: 40rem;
+    height: 40rem;
     overflow: scroll;
     background-color: $white;
     color: $black;
@@ -46,8 +45,7 @@
     cursor: pointer;
 
     @include tablet {
-      min-height: 44rem;
-      max-height: 45rem;
+      height: 44rem;
     }
   }
 }

--- a/src/components/Dropdown/dropdown.module.scss
+++ b/src/components/Dropdown/dropdown.module.scss
@@ -4,29 +4,27 @@
 
 .dropdown {
   position: relative;
+  z-index: 4;
   /* display: inline-block; */
 
   .dropdownBtn {
     display: flex;
     justify-content: space-between;
+    align-items: center;
     width: 100%;
     background-color: $white;
-    border: 1.5px solid $black;
+    border: 1px solid $black;
     border-radius: $brad-sm;
     padding: 0.5rem;
-    padding-top: 0.75rem;
 
     .arrowBtn {
       width: 1.3rem;
       height: 1.3rem;
-
-      &:hover {
-        cursor: pointer;
-      }
+      cursor: pointer;
     }
   }
 
-  .radiusNull {
+  .active {
     border-bottom-left-radius: 0;
     border-bottom-right-radius: 0;
   }
@@ -34,27 +32,22 @@
   .dropdownContent {
     position: absolute;
     width: 100%;
-    height: 40rem;
+    min-height: 39rem;
+    max-height: 40rem;
     overflow: scroll;
     background-color: $white;
     color: $black;
-    font-size: 0.85rem;
-    border: 1.5px solid $black;
+    font-size: 0.875rem;
+    border: 1px solid $black;
     border-top: 0;
     border-bottom-left-radius: $brad-sm;
     border-bottom-right-radius: $brad-sm;
     padding: 0.5rem;
+    cursor: pointer;
 
-    &:hover {
-      cursor: pointer;
-    }
-  }
-}
-
-@include tablet {
-  .dropdown {
-    .dropdownContent {
-      height: 45rem;
+    @include tablet {
+      min-height: 44rem;
+      max-height: 45rem;
     }
   }
 }

--- a/src/components/Game/Game.tsx
+++ b/src/components/Game/Game.tsx
@@ -7,6 +7,7 @@ import classNames from 'classnames';
 import { handleShuffle } from '@/utils/handleShuffle';
 import { showConfetti } from '@/utils/showConfetti';
 import { Button } from '../Button/Button';
+import { Dropdown } from '../Dropdown/Dropdown';
 import { LetterGrid } from '../LetterGrid/LetterGrid';
 import { Level } from '../Level/Level';
 import styles from './game.module.scss';
@@ -45,7 +46,6 @@ const levels = levelScores.map((score, i) => ({ level: i + 1, levelName: levelNa
 
 export const Game = ({ game }: GameProps) => {
   const { letters, totalScore, /* levelScores, */ matchedWords, panagrams } = game;
-
   const [gameLetters, setGameLetters] = useState(letters);
   const [wordInput, setWordInput] = useState('');
 
@@ -94,7 +94,7 @@ export const Game = ({ game }: GameProps) => {
           toast.success(`+${wordInput.length}`, { icon: '🐸' });
         }
 
-        setFoundWords((prev) => [...prev, wordInput]);
+        setFoundWords((prev) => [...prev, match.word]);
       }
     }
 
@@ -113,6 +113,7 @@ export const Game = ({ game }: GameProps) => {
       <BgLayers isAnimation={isAnimation} setIsAnimation={setIsAnimation} />
       <div className={styles.game}>
         <Level curScore={curScore} levels={levels} />
+        <Dropdown foundWords={foundWords} />
         <input className={styles.currentInput} value={wordInput} readOnly />
         <LetterGrid gameLetters={gameLetters} setWordInput={setWordInput} />
 

--- a/src/components/Hamburger/hamburger.module.scss
+++ b/src/components/Hamburger/hamburger.module.scss
@@ -35,9 +35,9 @@
     height: 2rem;
     top: 1rem;
     right: 1rem;
+    cursor: pointer;
 
     &:hover {
-      cursor: pointer;
       color: $white-75;
     }
   }
@@ -53,10 +53,7 @@
     li {
       padding-left: 2rem;
       width: 100%;
-
-      &:hover {
-        cursor: pointer;
-      }
+      cursor: pointer;
     }
   }
 }

--- a/src/components/LetterGrid/letterGrid.module.scss
+++ b/src/components/LetterGrid/letterGrid.module.scss
@@ -43,6 +43,7 @@
 
     button {
       color: $white;
+      font-size: 3rem;
       background-color: $ocher-90;
     }
     img {

--- a/src/components/Modal/modal.module.scss
+++ b/src/components/Modal/modal.module.scss
@@ -4,6 +4,7 @@
 
 .modalWrapper {
   position: absolute;
+  z-index: 5;
   left: 0;
   top: 0;
   width: 100%;


### PR DESCRIPTION
- made the dropdown higher so as to cover the BTNs below (letterBtn && 'eingabe'/'löschen') (closing works thru a click anywhere on the dropdown Btn or content; it saves us creating another modal --> wortify implements it like this as well)
- spacing between the inputs and the level comp is a bit too big - would wait with adjusting the flexbox though till the rest of the comps is on the page
- ISSUE: the letterBtns are still over the dropdown comp --> Z-Index stuff (in my browser the letterBtns also mess with the rules-modal)

- adjusted the font-size of the main letter (looks better a bit bigger), didn't create an extra feature for this